### PR TITLE
chore(workflow): build tauri.js after install

### DIFF
--- a/.github/workflows/build-node-examples.yml
+++ b/.github/workflows/build-node-examples.yml
@@ -83,6 +83,9 @@ jobs:
       - name: install cli deps via yarn
         working-directory: ./cli/tauri.js
         run: yarn
+      - name: build cli
+        working-directory: ./cli/tauri.js
+        run: yarn build
       - name: cache node modules
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Changes in the Tauri repo meant that we don't build on install, so we need to manually do it now.